### PR TITLE
Update jellyfin.json

### DIFF
--- a/jellyfin.json
+++ b/jellyfin.json
@@ -35,5 +35,5 @@
       }
     ]
   },
-  "revision": 4
+  "revision": 5
 }

--- a/jellyfin.json
+++ b/jellyfin.json
@@ -1,6 +1,6 @@
 {
   "name": "Jellyfin Server",
-  "release": "13.2-RELEASE",
+  "release": "13.3-RELEASE",
   "artifact": "https://github.com/spz2k9/iocage-plugin-jellyfin.git",
   "official": false,
   "properties": {


### PR DESCRIPTION
updated jail release to use 13.3-RELEASE in order to support Jellyfin 10.9.x